### PR TITLE
'venv' scheme is not preset on 3.10

### DIFF
--- a/build.py
+++ b/build.py
@@ -30,7 +30,7 @@ use_plugin("copy_resources")
 use_plugin("filter_resources")
 
 name = "wheel-axle-runtime"
-version = "0.0.8"
+version = "0.0.9"
 
 summary = "Axle Runtime is the runtime part of the Python Wheel enhancement library"
 authors = [Author("Karellen, Inc.", "supervisor@karellen.co")]

--- a/src/main/python/wheel_axle/runtime/_libpython.py
+++ b/src/main/python/wheel_axle/runtime/_libpython.py
@@ -91,7 +91,9 @@ class LibPythonInstaller(Installer):
             lib_path = os.path.join(site.USER_BASE, target_platlibdir)
             platlib_path = os.path.join(site.USER_BASE, platlibdir)
         elif in_venv:
-            target_platlibdir = compute_arch_lib_dir("venv")
+            target_platlibdir = compute_arch_lib_dir(
+                "venv" if "venv" in sysconfig.get_scheme_names() else
+                sysconfig.get_default_scheme())
             lib_path = os.path.join(sys.exec_prefix, target_platlibdir)
             platlib_path = os.path.join(sys.exec_prefix, platlibdir)
         else:


### PR DESCRIPTION
If venv scheme is not available, use default.

fixes #19